### PR TITLE
Add token-based authentication

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -81,8 +81,10 @@ def download(filename):
 @bottle.route('/upload', method='POST')
 def process_upload(db):
     user_file = bottle.request.files.get('upload')
+    token = bottle.request.forms.get('token')
+
     try:
-        runs.upload(db, user_file)
+        runs.upload(db, user_file, token)
     except:
         msg = str(sys.exc_info()[1])
         raise bottle.HTTPError(500, 'Error processing upload: {0:s}'.format(msg))

--- a/dashboard.py
+++ b/dashboard.py
@@ -78,10 +78,6 @@ def show_regressions_by_host(db):
 def download(filename):
     return bottle.static_file(filename, root='logs/', download=filename)
 
-@bottle.route('/upload')
-def show_upload_form():
-    return bottle.template('upload', url=bottle.url)
-
 @bottle.route('/upload', method='POST')
 def process_upload(db):
     user_file = bottle.request.files.get('upload')

--- a/runs.py
+++ b/runs.py
@@ -1,6 +1,7 @@
 import sys
 import sql.runs
 import sql.regressions
+import sql.auth
 import test_results
 import io
 import log_files
@@ -50,10 +51,14 @@ def by_hostname(db, name):
     runs = sql.runs.get_by_hostname(db, name)
     return _process_runs(runs, db)
 
-def upload(db, user_file):
+def upload(db, user_file, token):
+
     if user_file is None:
         raise RuntimeError("Uploaded file is not valid")
 
+    if not sql.auth.is_valid(db, token):
+        raise RuntimeError("Authentication failed")
+    
     # Save the uploaded file
     # NB: This needs to be done _before_ it is read from
     from uuid import uuid4

--- a/sql/auth.py
+++ b/sql/auth.py
@@ -1,0 +1,14 @@
+def is_valid(db, token):
+    query = """
+        select
+            count(1) as cnt
+        from
+            auth_token
+        where
+            token = ?
+    """
+    cur = db.cursor()
+    cur.execute(query, [token])
+    res = cur.fetchone()
+    cur.close()
+    return int(res['cnt']) == 1

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -91,3 +91,19 @@ select
     upload_file,
     compiler_name
 from run;
+
+CREATE TABLE auth_token (
+	"id" INTEGER NOT NULL PRIMARY KEY,
+	"token" TEXT,
+	"hostname" TEXT
+);
+
+insert into auth_token("hostname","token") values ("cayenne.cs.wisc.edu","ec2798c1fb37cce8d95d8e1d558bd519");
+insert into auth_token("hostname","token") values ("zeroah.cs.wisc.edu","b2f3bf6a6f317cde6b71547db132e797");
+insert into auth_token("hostname","token") values ("leela.cs.wisc.edu","1fa510720181141c3280b240094371d6");
+insert into auth_token("hostname","token") values ("zatar.cs.wisc.edu","d1549a402ea3fc0facedd5568230ba78");
+insert into auth_token("hostname","token") values ("ray.llnl.gov","14c2751e1fabf1a0954d4c14b5b8f896");
+insert into auth_token("hostname","token") values ("lassen.llnl.gov","3bd2daf2deca6d1fcbdc65116340b977");
+insert into auth_token("hostname","token") values ("quartz.llnl.gov","cd25856ec3b601bf1ad0e5efc9170247");
+insert into auth_token("hostname","token") values ("GalacticCentralPoint","14bb4ad2d33e1fa292c0561b7dad8232");
+insert into auth_token("hostname","token") values ("cori","2af8d40c965d41781327a4f97fe6452d");

--- a/views/runs.tpl
+++ b/views/runs.tpl
@@ -83,7 +83,5 @@
 	</table>
 % end
 
-<br><br>
-<a href="{{ url('/upload') }}">Upload a new run</a>
 </body>
 </html>

--- a/views/upload.tpl
+++ b/views/upload.tpl
@@ -1,4 +1,0 @@
-<form action="{{ url('/upload') }}" method="post" enctype="multipart/form-data">
-    Select a file: <input type="file" name="upload" />
-    <input type="submit" value="Start upload" />
-</form>


### PR DESCRIPTION
This is the same authentication method used by [CDash](https://blog.kitware.com/cdash-authenticated-submissions/) except that the tokens are mapped to a host, rather than a user, since we are generally running on secured machines.