### PR TITLE
Track and display compiler information

### DIFF
--- a/log_files.py
+++ b/log_files.py
@@ -2,8 +2,34 @@ from io import TextIOWrapper
 from os.path import split as path_split
 
 def read_compiler_logs(tar, root_dir, tar_files):
-    res = {}
-    for d in ('dyninst','testsuite'):
+    res = {
+        'compiler': {
+            'dyninst': {
+                'c': {
+                    'path': '',
+                    'name': '',
+                    'version': ''
+                },
+                'cxx': {
+                    'path': '',
+                    'name': '',
+                    'version': ''
+                }
+            },
+            'testsuite': {
+                'c': {
+                    'path': '',
+                    'name': '',
+                    'version': ''
+                },
+                'cxx': {
+                    'path': '',
+                    'name': '',
+                    'version': ''
+                }
+            }
+        }}
+    for d in ('dyninst', 'testsuite'):
         logfile = "{0:s}/{1:s}/compilers.conf".format(root_dir, d)
         if logfile in tar_files:
             compiler_log = tar.extractfile(logfile)
@@ -12,13 +38,13 @@ def read_compiler_logs(tar, root_dir, tar_files):
                 path = compiler_results['{0:s}_path'.format(lang)]
                 (dir_name, base) = path_split(path)
                 res['compiler'][d][lang]['path'] = dir_name
-                res['compiler'][d][lang]['vendor'] = base
+                res['compiler'][d][lang]['name'] = base
                 res['compiler'][d][lang]['version'] = compiler_results['{0:s}_version'.format(lang)]
     return res
 
 def read_git_logs(tar, root_dir, tar_files):
     res = {}
-    for d in ('dyninst','testsuite'):
+    for d in ('dyninst', 'testsuite'):
         logfile = "{0:s}/{1:s}/git.log".format(root_dir, d)
         if logfile in tar_files:
             git_log = tar.extractfile(logfile)

--- a/log_files.py
+++ b/log_files.py
@@ -1,4 +1,20 @@
 from io import TextIOWrapper
+from os.path import split as path_split
+
+def read_compiler_logs(tar, root_dir, tar_files):
+    res = {}
+    for d in ('dyninst','testsuite'):
+        logfile = "{0:s}/{1:s}/compilers.conf".format(root_dir, d)
+        if logfile in tar_files:
+            compiler_log = tar.extractfile(logfile)
+            compiler_results = read_properties(TextIOWrapper(compiler_log, encoding='utf-8'))
+            for lang in ('c', 'cxx'):
+                path = compiler_results['{0:s}_path'.format(lang)]
+                (dir_name, base) = path_split(path)
+                res['compiler'][d][lang]['path'] = dir_name
+                res['compiler'][d][lang]['vendor'] = base
+                res['compiler'][d][lang]['version'] = compiler_results['{0:s}_version'.format(lang)]
+    return res
 
 def read_git_logs(tar, root_dir, tar_files):
     res = {}

--- a/log_files.py
+++ b/log_files.py
@@ -30,7 +30,7 @@ def read_compiler_logs(tar, root_dir, tar_files):
             }
         }}
     for d in ('dyninst', 'testsuite'):
-        logfile = "{0:s}/{1:s}/compilers.conf".format(root_dir, d)
+        logfile = "{0:s}/{1:s}/build/compilers.conf".format(root_dir, d)
         if logfile in tar_files:
             compiler_log = tar.extractfile(logfile)
             compiler_results = read_properties(TextIOWrapper(compiler_log, encoding='utf-8'))

--- a/runs.py
+++ b/runs.py
@@ -103,6 +103,18 @@ def upload(db, user_file):
             # There may be a trailing period in the UTC date
             # Sqlite doesn't like that, so remove it
             results['date'] = results['date'].replace('.', '')
+            
+            print(files)
+            print("\n\n")
+            
+            # Gather compiler information
+            results.update(log_files.read_compiler_logs(tar, results['root_dir'], files))
+            
+            from pprint import pprint
+            pprint(results)
+            import os
+            os.unlink('logs/' + file_name)
+            raise RuntimeError("moo")
 
             # Save the run information
             try:
@@ -125,5 +137,5 @@ def upload(db, user_file):
                     raise RuntimeError("Error inserting test_results: {0:s}".format(e))
     except(tarfile.ReadError):
         from os import unlink
-        unlink(file_name)
+        unlink('logs/' + file_name)
         raise RuntimeError("'{0:s}' is not a valid tarfile".format(user_file.filename))

--- a/runs.py
+++ b/runs.py
@@ -103,18 +103,9 @@ def upload(db, user_file):
             # There may be a trailing period in the UTC date
             # Sqlite doesn't like that, so remove it
             results['date'] = results['date'].replace('.', '')
-            
-            print(files)
-            print("\n\n")
-            
+
             # Gather compiler information
             results.update(log_files.read_compiler_logs(tar, results['root_dir'], files))
-            
-            from pprint import pprint
-            pprint(results)
-            import os
-            os.unlink('logs/' + file_name)
-            raise RuntimeError("moo")
 
             # Save the run information
             try:

--- a/sql/compiler.py
+++ b/sql/compiler.py
@@ -1,0 +1,28 @@
+def create(db, vendor, path, version, language):
+    query = "INSERT INTO compiler(name,path,version,language) VALUES (?,?,?,?)"
+    cur = db.cursor()
+    cur.execute(query, [vendor, path, version, language])
+    db.commit()
+    rowid = cur.lastrowid
+    cur.close()
+    return rowid
+
+def get(db, vendor, path, version, language):
+    query = """
+        select
+            id
+        from compiler
+        where
+            name = ?
+            and path = ?
+            and version = ?
+            and language = ?
+    """
+    cur = db.cursor()
+    cur.execute(query, [vendor, path, version, language])
+    res = cur.fetchone()
+    cur.close()
+
+    if res:
+        return res[0]
+    return res

--- a/sql/runs.py
+++ b/sql/runs.py
@@ -9,19 +9,19 @@ def create(db, properties):
         'testsuite_commit', 'testsuite_branch'
     ]
     values = [properties[k] for k in fields]
-    
+
     fields.append('kernel_version')
     values.append(properties['version'])
-    
+
     fields.append('upload_file')
     values.append(properties['user_file'])
-    
+
     fields.append('run_date')
     values.append(properties['date'])
 
     # Create the run (datetime is UTC)
     query = "INSERT INTO run({0:s},upload_date) VALUES ({1:s},datetime('now'))"
-    query = query.format(','.join(fields),','.join(['?']*len(values)))
+    query = query.format(','.join(fields), ','.join(['?'] * len(values)))
     cur = db.cursor()
     cur.execute(query, values)
     db.commit()
@@ -86,11 +86,11 @@ def get(db_conn, limit=None, order_by=None, runid=None):
             run_v.*
         from run_v
         where 1=1 """
-    
+
     if runid is not None:
         query += " and id = ? "
     if order_by is not None:
-        query += " order by {0:s} desc".format(order_by)    
+        query += " order by {0:s} desc".format(order_by)
     if limit is not None:
         query += " limit {0:d}".format(int(limit))
 
@@ -104,7 +104,7 @@ def get(db_conn, limit=None, order_by=None, runid=None):
 def _create_most_recent_table(db, runid):
     """
         !!! Internal use only !!!
-        
+
         Select the most recent run on every host,
         except the one specified by 'runid',
         with the same architecture as the run

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -35,6 +35,17 @@ create table run(
 	"upload_file" TEXT
 );
 
+CREATE TABLE compiler (
+	"id" INTEGER NOT NULL PRIMARY KEY,
+	"runid" INTEGER NOT NULL,
+	"vendor" TEXT,
+	"path" TEXT,
+	"version" TEXT,
+	"language" TEXT,
+	"target" TEXT,
+	FOREIGN KEY(runid) REFERENCES run(id)
+);
+
 create table test_result(
 	"resultid" INTEGER NOT NULL PRIMARY KEY,
 	"runid" INTEGER NOT NULL,

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -32,18 +32,25 @@ create table run(
 	"dyninst_branch" TEXT,
 	"testsuite_commit" TEXT,
 	"testsuite_branch" TEXT,
-	"upload_file" TEXT
+	"upload_file" TEXT,
+	"compiler_name" TEXT
 );
 
 CREATE TABLE compiler (
 	"id" INTEGER NOT NULL PRIMARY KEY,
-	"runid" INTEGER NOT NULL,
-	"vendor" TEXT,
+	"name" TEXT,
 	"path" TEXT,
 	"version" TEXT,
-	"language" TEXT,
+	"language" TEXT
+);
+
+CREATE TABLE run_compiler (
+	"id" INTEGER NOT NULL PRIMARY KEY,
+	"runid" INTEGER NOT NULL,
+	"compilerid" INTEGER NOT NULL,
 	"target" TEXT,
-	FOREIGN KEY(runid) REFERENCES run(id)
+	FOREIGN KEY(runid) references run(id),
+	FOREIGN KEY(compilerid) references compiler(id)
 );
 
 create table test_result(
@@ -81,5 +88,6 @@ select
     dyninst_branch,
     testsuite_commit,
     testsuite_branch,
-    upload_file
+    upload_file,
+    compiler_name
 from run;

--- a/views/runs.tpl
+++ b/views/runs.tpl
@@ -12,6 +12,7 @@
 	<th>Date</th>
 	<th>Arch</th>
 	<th>Host</th>
+	<th>Compiler Name</th>
 	<th>libc</th>
 	<th>Dyninst Build</th>
 	<th>Tests Build</th>
@@ -44,6 +45,7 @@
 		<td align="center">{{r['run_date']}}</td>
 		<td align="center">{{r['arch']}}/{{r['vendor']}}</td>
 		<td align="center">{{r['hostname']}}</td>
+		<td align="center">{{r['compiler_name']}}</td>
 		<td align="center">{{r['libc']}}</td>
 	
 	%	bgcolor = get_status_color(r['dyninst_build_status'])


### PR DESCRIPTION
Requires https://github.com/dyninst/testsuite/pull/89

There is a lot of information tracked for the C and C++ compilers used to build Dyninst and the test suite. For now, only the most basic information is shown in the dashboard to keep the interface clutter to a minimum.