### PR TITLE
Save regressions in a table when entering a new run

### DIFF
--- a/regressions.py
+++ b/regressions.py
@@ -1,6 +1,16 @@
 import sql.regressions
 import sql.runs
 
+def create(db, cur_id):
+    """
+        Enumerate the regressions caused by the run 'run_id'
+    """
+    regs = by_arch(db, cur_id)
+
+    for res in regs['results']:
+        if res['regressions']:
+            sql.regressions.create(db, cur_id, res['run']['id'], len(res['regressions']))
+
 def by_arch(db, cur_id):
     """
         Compare the run specified by `cur_id` against the most

--- a/sql/setup.sql
+++ b/sql/setup.sql
@@ -97,3 +97,14 @@ CREATE TABLE auth_token (
 	"token" TEXT,
 	"hostname" TEXT
 );
+
+CREATE TABLE regression_count (
+	"id" INTEGER NOT NULL PRIMARY KEY,
+	"cur_run" INTEGER NOT NULL,
+	"prev_run" INTEGER NOT NULL,
+	"cnt" INTEGER,
+	FOREIGN KEY(cur_run) references run(id),
+	FOREIGN KEY(prev_run) references run(id)
+);
+CREATE UNIQUE INDEX regression_count_unique ON regression_count(cur_run,prev_run); 
+


### PR DESCRIPTION
This drops the load time of the dashboard by ~6x.

NB: This does not encapsulate _all_ possible regressions- just the ones that are from the most recent run on the same architecture as the run being created.