### PR TITLE
Change default compiler name to 'Unknown'

### DIFF
--- a/log_files.py
+++ b/log_files.py
@@ -7,24 +7,24 @@ def read_compiler_logs(tar, root_dir, tar_files):
             'dyninst': {
                 'c': {
                     'path': '',
-                    'name': '',
+                    'name': 'Unknown',
                     'version': ''
                 },
                 'cxx': {
                     'path': '',
-                    'name': '',
+                    'name': 'Unknown',
                     'version': ''
                 }
             },
             'testsuite': {
                 'c': {
                     'path': '',
-                    'name': '',
+                    'name': 'Unknown',
                     'version': ''
                 },
                 'cxx': {
                     'path': '',
-                    'name': '',
+                    'name': 'Unknown',
                     'version': ''
                 }
             }


### PR DESCRIPTION
In cases where the configuration portion of the build does not complete,
then no compiler log is created. In such a case, the compiler should be
referred to as 'Unknown' rather than just a blank string.