### PR TITLE
Make runs sortable in display

### DIFF
--- a/views/run.header.tpl
+++ b/views/run.header.tpl
@@ -2,19 +2,19 @@
 # The header for displaying a run or sequence of runs
 %> 
 
-<table border="1">
+<table border="1" id="results">
 <tr>
-<th>Run</th>
-<th>Date</th>
-<th>Arch</th>
-<th>Host</th>
-<th>Compiler Name</th>
-<th>libc</th>
-<th>Dyninst Build</th>
-<th>Tests Build</th>
+<th onclick="w3.sortHTML('#results', '.item', 'td:nth-child(1)')" style="cursor:pointer">Run</th>
+<th onclick="w3.sortHTML('#results', '.item', 'td:nth-child(2)')" style="cursor:pointer">Date</th>
+<th onclick="w3.sortHTML('#results', '.item', 'td:nth-child(3)')" style="cursor:pointer">Arch</th>
+<th onclick="w3.sortHTML('#results', '.item', 'td:nth-child(4)')" style="cursor:pointer">Host</th>
+<th onclick="w3.sortHTML('#results', '.item', 'td:nth-child(5)')" style="cursor:pointer">Compiler Name</th>
+<th onclick="w3.sortHTML('#results', '.item', 'td:nth-child(6)')" style="cursor:pointer">libc</th>
+<th onclick="w3.sortHTML('#results', '.item', 'td:nth-child(7)')" style="cursor:pointer">Dyninst Build</th>
+<th onclick="w3.sortHTML('#results', '.item', 'td:nth-child(8)')" style="cursor:pointer">Tests Build</th>
 <th>Test Results</th>
-<th>Regressions</th>
-<th>Dyninst</th>
-<th>Testsuite</th>
+<th onclick="w3.sortHTML('#results', '.item', 'td:nth-child(9)')" style="cursor:pointer">Regressions</th>
+<th onclick="w3.sortHTML('#results', '.item', 'td:nth-child(10)')" style="cursor:pointer">Dyninst</th>
+<th onclick="w3.sortHTML('#results', '.item', 'td:nth-child(11)')" style="cursor:pointer">Testsuite</th>
 <th>Log Files</th>
 </tr>

--- a/views/run.row.tpl
+++ b/views/run.row.tpl
@@ -25,7 +25,7 @@ if run is not None:
 	end
 %>
 
-	<tr>
+	<tr class="item">
 	<td align="center"><a href="{{ url('/details') }}/{{ run['runid'] }}">{{ run['runid'] }}</a></td>
 	<td align="center">{{run['run_date']}}</td>
 	<td align="center">{{run['arch']}}/{{run['vendor']}}</td>

--- a/views/runs.tpl
+++ b/views/runs.tpl
@@ -3,6 +3,7 @@
 <head>
 	<title>Dyninst Test Suite Results</title>
 </head>
+<script src="https://www.w3schools.com/lib/w3.js"></script>
 <body>
 
 % if len(runs) == 0:


### PR DESCRIPTION
This makes most of the columns in the 'runs' landing page sortable by clicking on the headers.